### PR TITLE
Publish deps

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.1.2/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.1.0/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.4.2/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.4.0/"
   }
 }

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.2.0/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.8.0/mod.ts"
   }
 }


### PR DESCRIPTION
Verify: https://deno.land/x?query=slack

I noticed this sample is several minor versions behind, so perhaps there's a reason for this. Feel free to reject the changes if we want to continue using older versions!