### PR TITLE
Use the built-in client instead of manually instantiating SlackAPI client

### DIFF
--- a/functions/send_time_off_request_to_manager/block_actions.ts
+++ b/functions/send_time_off_request_to_manager/block_actions.ts
@@ -1,4 +1,3 @@
-import { SlackAPI } from "deno-slack-api/mod.ts";
 import { SendTimeOffRequestToManagerFunction } from "./definition.ts";
 import { BlockActionHandler } from "deno-slack-sdk/types.ts";
 import { APPROVE_ID } from "./constants.ts";
@@ -6,9 +5,8 @@ import timeOffRequestHeaderBlocks from "./blocks.ts";
 
 const block_actions: BlockActionHandler<
   typeof SendTimeOffRequestToManagerFunction.definition
-> = async function ({ action, body, token }) {
+> = async function ({ action, body, client }) {
   console.log("Incoming action handler invocation", action);
-  const client = SlackAPI(token);
 
   const approved = action.action_id === APPROVE_ID;
 

--- a/functions/send_time_off_request_to_manager/block_actions_test.ts
+++ b/functions/send_time_off_request_to_manager/block_actions_test.ts
@@ -1,6 +1,7 @@
 import * as mf from "https://deno.land/x/mock_fetch@0.3.0/mod.ts";
 import handler from "./block_actions.ts";
 import { APPROVE_ID } from "./constants.ts";
+import { SlackAPI } from "deno-slack-api/mod.ts";
 
 // Replaces globalThis.fetch with the mocked copy
 mf.install();
@@ -73,6 +74,7 @@ Deno.test("SendTimeOffRequestToManagerFunction runs successfully", async () => {
     },
     env: { LOG_LEVEL: "ERROR" },
     token: "valid-token",
+    client: SlackAPI("valid-token", {}),
     // deno-lint-ignore no-explicit-any
   } as any;
   await handler(context);

--- a/functions/send_time_off_request_to_manager/mod.ts
+++ b/functions/send_time_off_request_to_manager/mod.ts
@@ -1,5 +1,4 @@
 import { SendTimeOffRequestToManagerFunction } from "./definition.ts";
-import { SlackAPI } from "deno-slack-api/mod.ts";
 import { SlackFunction } from "deno-slack-sdk/mod.ts";
 import BlockActionHandler from "./block_actions.ts";
 import { APPROVE_ID, DENY_ID } from "./constants.ts";
@@ -10,9 +9,8 @@ import timeOffRequestHeaderBlocks from "./blocks.ts";
 // interactive buttons: one to approve, and one to deny.
 export default SlackFunction(
   SendTimeOffRequestToManagerFunction,
-  async ({ inputs, token }) => {
+  async ({ inputs, client }) => {
     console.log("Forwarding the following time off request:", inputs);
-    const client = SlackAPI(token, {});
 
     // Create a block of Block Kit elements composed of several header blocks
     // plus the interactive approve/deny buttons at the end

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,5 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.4.2/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.4.0/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.4.2/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,5 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.4.2/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.4.2/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.4.0/"
   }
 }


### PR DESCRIPTION
This gives support for executing samples in slack dev environment for free.

### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

Describe the goal of this PR. Mention any related Issue numbers. 

If you are introducing a new sample app in this pull request, please also include a detailed description of the application’s purpose and functionality.

### Requirements (place an x in each [ ] that applies)

- [ ] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [ ] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
