### PR TITLE
Update to use TriggerContextData and disable deno lock

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,5 +21,6 @@
   "importMap": "import_map.json",
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test --allow-read --allow-none"
-  }
+  },
+  "lock": false
 }

--- a/triggers/trigger.ts
+++ b/triggers/trigger.ts
@@ -1,8 +1,8 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData } from "deno-slack-api/mod.ts";
+import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
 
 const trigger: Trigger = {
-  type: "shortcut",
+  type: TriggerTypes.Shortcut,
   name: "Request Time Off",
   description: "Ask your manager for some time off",
   workflow: "#/workflows/create_time_off",

--- a/triggers/trigger.ts
+++ b/triggers/trigger.ts
@@ -1,4 +1,5 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
+import { TriggerContextData } from "deno-slack-api/mod.ts";
 
 const trigger: Trigger = {
   type: "shortcut",
@@ -7,7 +8,7 @@ const trigger: Trigger = {
   workflow: "#/workflows/create_time_off",
   inputs: {
     interactivity: {
-      value: "{{data.interactivity}}",
+      value: TriggerContextData.Shortcut.interactivity,
     },
   },
 };


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

Use the `TriggerTypes` object, the `TriggerContextData` object instead of using the templatized strings like `{{data.interactivity}}`, and disable `deno.lock` based on recent convos

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
