### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,9 +30,9 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
     "@std/assert": "jsr:@std/assert@^1.0.15",
-    "@std/testing": "jsr:@std/testing@^1.0.16",
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/"
+    "@std/testing": "jsr:@std/testing@^1.0.16"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,7 +31,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
     "@std/assert": "jsr:@std/assert@^1.0.15",
     "@std/testing": "jsr:@std/testing@^1.0.16"
   }

--- a/functions/send_time_off_request_to_manager/definition.ts
+++ b/functions/send_time_off_request_to_manager/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
 /**
  * Custom function that sends a message to the user's manager asking for approval
  * for the time off request. The message includes some Block Kit with two interactive

--- a/functions/send_time_off_request_to_manager/mod.ts
+++ b/functions/send_time_off_request_to_manager/mod.ts
@@ -1,5 +1,5 @@
 import { SendTimeOffRequestToManagerFunction } from "./definition.ts";
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
+import { SlackFunction } from "@slack/sdk";
 import { APPROVE_ID, DENY_ID } from "./constants.ts";
 import timeOffRequestHeaderBlocks from "./blocks.ts";
 

--- a/functions/send_time_off_request_to_manager/mod_test.ts
+++ b/functions/send_time_off_request_to_manager/mod_test.ts
@@ -1,5 +1,5 @@
 import { stub } from "@std/testing/mock";
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals } from "@std/assert";
 import handler from "./mod.ts";
 

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 import { CreateTimeOffRequestWorkflow } from "./workflows/CreateTimeOffRequestWorkflow.ts";
 import { SendTimeOffRequestToManagerFunction } from "./functions/send_time_off_request_to_manager/definition.ts";
 

--- a/triggers/trigger.ts
+++ b/triggers/trigger.ts
@@ -1,5 +1,5 @@
-import type { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import type { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 
 const trigger: Trigger = {
   type: TriggerTypes.Shortcut,

--- a/workflows/CreateTimeOffRequestWorkflow.ts
+++ b/workflows/CreateTimeOffRequestWorkflow.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { SendTimeOffRequestToManagerFunction } from "../functions/send_time_off_request_to_manager/definition.ts";
 
 /**


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)